### PR TITLE
Switch he busybox binaries from /latest/ to /1.21.1/

### DIFF
--- a/3rdparty/busybox.url
+++ b/3rdparty/busybox.url
@@ -1,1 +1,1 @@
-https://busybox.net/downloads/binaries/latest/busybox-armv7l
+https://busybox.net/downloads/binaries/1.21.1/busybox-armv7l


### PR DESCRIPTION
The /lastest/ link is no longer available. It is also more reliable to link
to a fix version to ensure that all cloned repos are using the same.


This addresses issue #3 