### PR TITLE
Add `patch` and `unpatch` to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ clean:
 	@make -C 3rdparty/sunxi-tools clean
 	@make -C 3rdparty/mkbootimg clean
 
+patch:
+	patch ./3rdparty/sunxi-tools/fel_lib.c < ./3rdparty/sunxi-tools.diff
+
+unpatch:
+	git --work-tree=3rdparty/sunxi-tools --git-dir=3rdparty/sunxi-tools/.git checkout -f - fel_lib.c
+
 bin/sunxi-fel: 3rdparty/sunxi-tools/sunxi-fel
 	@cp $< $@
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ sudo apt-get install libusb-1.0-0-dev libqt4-dev libudev-dev upx-ucl
 # Build
 
 ```
-patch ./3rdparty/sunxi-tools/fel_lib.c < ./3rdparty/sunxi-tools.diff
+make patch
 make
 ```


### PR DESCRIPTION
This allows us to patch / unpatch the git submodules (sunxi-tools for now).

I'm not sure if the patch is required (I haven't run the binary yet). What i know is that with clang on macOS the patched file doesn't compile because we endup adding `return 0;` to methods declared as `void`.

Nevertheless if the patching should be done it is now moved to the makefile (but not made as a target of existing rules) and a cleanup rule was added too.