### PR TITLE
Fix macOS readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you don't already have homebrew installed on your Mac:
 The actual build dependencies:
 
 ```
-brew install libusb qt wget upx cpio lzop wget
+brew install libusb qt wget upx lzop wget
 brew link qt --force
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,16 +11,20 @@ git submodule update
 
 ## Install the build dependencies
 
-### Mac OS X 10.12
+### macOS 10.12
 
 If you don't already have homebrew installed on your Mac:
 
 ```
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
 
+The actual build dependencies:
+
+```
 brew install libusb qt wget upx cpio lzop wget
 brew link qt --force
+```
 
 ### Ubuntu 16.04
 


### PR DESCRIPTION
The brew installation command was incomplete. The section about the
installation of the compilation dependencies wasn't in a markdown block.