### PR TITLE
use correct case for QUrl

### DIFF
--- a/hakchi-gui/src/main.cpp
+++ b/hakchi-gui/src/main.cpp
@@ -10,7 +10,7 @@
 #endif
 #ifdef __APPLE__
 #include <CoreFoundation/CoreFoundation.h>
-#include <QURL>
+#include <QUrl>
 #endif
 
 static QFileInfo appFileInfo_init()


### PR DESCRIPTION
fixes compilation on case-sensitive macOS systems