### PR TITLE
Mac: must link against CoreFoundation

### DIFF
--- a/hakchi-gui/hakchi-gui.pro
+++ b/hakchi-gui/hakchi-gui.pro
@@ -18,6 +18,7 @@ macx {
     QMAKE_LFLAGS_PLUGIN -= -dynamiclib
     QMAKE_LFLAGS_PLUGIN += -bundle
     MAKE_EXTENSION_SHLIB = bundle
+    LIBS += -framework CoreFoundation
 }
 
 SOURCES += $${PWD}/../3rdparty/sunxi-tools/fel_lib.c


### PR DESCRIPTION
This fixes a build error I noticed on OS X 10.13, where it failed at linktime due to not having access to three CoreFoundation functions:

```
Undefined symbols for architecture x86_64:
  "_CFAutorelease", referenced from:
      appPath() in main.o
  "_CFBundleCopyBundleURL", referenced from:
      appPath() in main.o
  "_CFBundleGetMainBundle", referenced from:
      appPath() in main.o
```